### PR TITLE
Refactor package names: Remove underscores for consistency

### DIFF
--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/App.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/App.kt
@@ -15,13 +15,13 @@ import androidx.navigation.navArgument
 import com.google.jetfit.presentation.screens.Screens
 import com.google.jetfit.presentation.screens.favorites.FavoritesScreen
 import com.google.jetfit.presentation.screens.home.HomeScreen
-import com.google.jetfit.presentation.screens.more_options.MoreOptionsScreen
+import com.google.jetfit.presentation.screens.moreoptions.MoreOptionsScreen
 import com.google.jetfit.presentation.screens.player.audio.AudioPlayerScreen
 import com.google.jetfit.presentation.screens.player.video.VideoPlayerScreen
-import com.google.jetfit.presentation.screens.profileSelector.ProfileSelectorScreen
+import com.google.jetfit.presentation.screens.profileselector.ProfileSelectorScreen
 import com.google.jetfit.presentation.screens.subscription.SubscriptionScreen
 import com.google.jetfit.presentation.screens.training.TrainingScreen
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityScreen
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityScreen
 import com.google.jetfit.presentation.utils.navigateTo
 import com.google.jetfit.presentation.utils.navigationDrawerGraph
 

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/dashboard/DashboardScreen.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/dashboard/DashboardScreen.kt
@@ -16,14 +16,14 @@ import androidx.navigation.compose.composable
 import com.google.jetfit.presentation.screens.Screens
 import com.google.jetfit.presentation.screens.favorites.FavoritesScreen
 import com.google.jetfit.presentation.screens.home.HomeScreen
-import com.google.jetfit.presentation.screens.more_options.MoreOptionsScreen
+import com.google.jetfit.presentation.screens.moreoptions.MoreOptionsScreen
 import com.google.jetfit.presentation.screens.player.audio.AudioPlayerScreen
 import com.google.jetfit.presentation.screens.player.video.VideoPlayerScreen
 import com.google.jetfit.presentation.screens.search.SearchScreen
 import com.google.jetfit.presentation.screens.settings.SettingsScreen
 import com.google.jetfit.presentation.screens.subscription.SubscriptionScreen
 import com.google.jetfit.presentation.screens.training.TrainingScreen
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityScreen
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityScreen
 
 
 @Composable

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/MoreOptionsScreen.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/MoreOptionsScreen.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.more_options
+package com.google.jetfit.presentation.screens.moreoptions
 
 import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
@@ -14,9 +14,9 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.jetfit.R
-import com.google.jetfit.presentation.screens.more_options.composable.BackRowSchema
-import com.google.jetfit.presentation.screens.more_options.composable.MoreOptionsButton
-import com.google.jetfit.presentation.screens.more_options.composable.TrainingDetails
+import com.google.jetfit.presentation.screens.moreoptions.composable.BackRowSchema
+import com.google.jetfit.presentation.screens.moreoptions.composable.MoreOptionsButton
+import com.google.jetfit.presentation.screens.moreoptions.composable.TrainingDetails
 
 
 @Composable

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/MoreOptionsUiState.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/MoreOptionsUiState.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.more_options
+package com.google.jetfit.presentation.screens.moreoptions
 
 import com.google.jetfit.data.entities.TrainingDetails
 

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/MoreOptionsViewModel.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/MoreOptionsViewModel.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.more_options
+package com.google.jetfit.presentation.screens.moreoptions
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/composable/BackRowSchema.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/composable/BackRowSchema.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.more_options.composable
+package com.google.jetfit.presentation.screens.moreoptions.composable
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/composable/MoreOptionsButton.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/composable/MoreOptionsButton.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.more_options.composable
+package com.google.jetfit.presentation.screens.moreoptions.composable
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.PaddingValues

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/composable/TrainingDetailsCard.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/moreoptions/composable/TrainingDetailsCard.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.more_options.composable
+package com.google.jetfit.presentation.screens.moreoptions.composable
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/profileselector/ProfileSelectorScreen.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/profileselector/ProfileSelectorScreen.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.profileSelector
+package com.google.jetfit.presentation.screens.profileselector
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/profileselector/ProfileSelectorUiState.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/profileselector/ProfileSelectorUiState.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.profileSelector
+package com.google.jetfit.presentation.screens.profileselector
 
 import javax.annotation.concurrent.Immutable
 

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/profileselector/ProfileSelectorViewModel.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/profileselector/ProfileSelectorViewModel.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.profileSelector
+package com.google.jetfit.presentation.screens.profileselector
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/TrainingEntityPages.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/TrainingEntityPages.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.training.training_entities
+package com.google.jetfit.presentation.screens.training.trainingentities
 
 sealed class TrainingEntityPages {
     data object EntityDetails : TrainingEntityPages()

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/TrainingEntityScreen.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/TrainingEntityScreen.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.training.training_entities
+package com.google.jetfit.presentation.screens.training.trainingentities
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
@@ -13,9 +13,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.google.jetfit.presentation.screens.training.training_entities.composables.ChallengeTabs
-import com.google.jetfit.presentation.screens.training.training_entities.composables.RoundedGradientImage
-import com.google.jetfit.presentation.screens.training.training_entities.composables.TrainingEntityDetails
+import com.google.jetfit.presentation.screens.training.trainingentities.composables.ChallengeTabs
+import com.google.jetfit.presentation.screens.training.trainingentities.composables.RoundedGradientImage
+import com.google.jetfit.presentation.screens.training.trainingentities.composables.TrainingEntityDetails
 
 @Composable
 fun TrainingEntityScreen(

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/TrainingEntityUiState.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/TrainingEntityUiState.kt
@@ -1,10 +1,10 @@
-package com.google.jetfit.presentation.screens.training.training_entities
+package com.google.jetfit.presentation.screens.training.trainingentities
 
 import com.google.jetfit.R
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityUiState.ContentType.CHALLENGES
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityUiState.ContentType.ROUTINE
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityUiState.ContentType.SERIES
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityUiState.ContentType.WORK_OUT
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityUiState.ContentType.CHALLENGES
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityUiState.ContentType.ROUTINE
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityUiState.ContentType.SERIES
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityUiState.ContentType.WORK_OUT
 
 data class TrainingEntityUiState(
     val contentType: ContentType = ROUTINE,

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/TrainingEntityViewModel.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/TrainingEntityViewModel.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.training.training_entities
+package com.google.jetfit.presentation.screens.training.trainingentities
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/ChallengeTabRowIndicator.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/ChallengeTabRowIndicator.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.training.training_entities.composables
+package com.google.jetfit.presentation.screens.training.trainingentities.composables
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/ChallengeTabs.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/ChallengeTabs.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.training.training_entities.composables
+package com.google.jetfit.presentation.screens.training.trainingentities.composables
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -32,7 +32,7 @@ import androidx.tv.material3.TabRow
 import androidx.tv.material3.Text
 import com.google.jetfit.R
 import com.google.jetfit.components.CustomCard
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityUiState
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityUiState
 
 @OptIn(ExperimentalTvMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/ChallengesPlanButton.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/ChallengesPlanButton.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.training.training_entities.composables
+package com.google.jetfit.presentation.screens.training.trainingentities.composables
 
 import androidx.compose.animation.animateColor
 import androidx.compose.animation.core.updateTransition

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/RoundedGradientImage.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/RoundedGradientImage.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.training.training_entities.composables
+package com.google.jetfit.presentation.screens.training.trainingentities.composables
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable

--- a/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/TrainingEntityDetails.kt
+++ b/JetFit/app/src/main/java/com/google/jetfit/presentation/screens/training/trainingentities/composables/TrainingEntityDetails.kt
@@ -1,4 +1,4 @@
-package com.google.jetfit.presentation.screens.training.training_entities.composables
+package com.google.jetfit.presentation.screens.training.trainingentities.composables
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
@@ -24,13 +24,13 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import com.google.jetfit.R
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityUiState
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityUiState.ContentType.CHALLENGES
-import com.google.jetfit.presentation.screens.training.training_entities.TrainingEntityUiState.ContentType.ROUTINE
-import com.google.jetfit.presentation.screens.training.training_entities.getSecondaryButtonID
-import com.google.jetfit.presentation.screens.training.training_entities.getSecondaryButtonIcon
-import com.google.jetfit.presentation.screens.training.training_entities.getStartButtonID
-import com.google.jetfit.presentation.screens.training.training_entities.isSecondaryButtonVisible
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityUiState
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityUiState.ContentType.CHALLENGES
+import com.google.jetfit.presentation.screens.training.trainingentities.TrainingEntityUiState.ContentType.ROUTINE
+import com.google.jetfit.presentation.screens.training.trainingentities.getSecondaryButtonID
+import com.google.jetfit.presentation.screens.training.trainingentities.getSecondaryButtonIcon
+import com.google.jetfit.presentation.screens.training.trainingentities.getStartButtonID
+import com.google.jetfit.presentation.screens.training.trainingentities.isSecondaryButtonVisible
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable


### PR DESCRIPTION
Refactor package naming: 
  - Renamed `more_options` to `moreoptions`.
  - Renamed `training_entities` to `trainingentities`.
  - Renamed `profileSelector` to `profileselector`.
  
Reported by @imhsp in [android/tv-samples#183 (comment)](https://github.com/android/tv-samples/pull/183#discussion_r1836828089)